### PR TITLE
Updated Symfony deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "kherge/amend": "2.*",
         "kherge/elf": "1.*",
         "kherge/version": "1.*",
-        "symfony/console": "2.1.*",
-        "symfony/finder": "2.1.*",
-        "symfony/process": "2.1.*"
+        "symfony/console": "~2.1",
+        "symfony/finder": "~2.1",
+        "symfony/process": "~2.1"
     },
 
     "autoload": {


### PR DESCRIPTION
I think it is safe to allow more than just the 2.1 version of the Symfony deps as these components won't have any BC breaks.
