### PR TITLE
Fixed the composer requirement for phpseclib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "herrera-io/json": "~1.0",
         "kherge/amend": "~3.0",
         "justinrainbow/json-schema": "~1.3",
-        "phpseclib/phpseclib": "dev-master",
+        "phpseclib/phpseclib": "~0.3",
         "symfony/console": "~2.1",
         "symfony/finder": "~2.1",
         "symfony/process": "~2.1"


### PR DESCRIPTION
The new constraint has several advantages:
- it allows using stable releases instead of forcing the dev version (easier when including Box as a requirement)
- it uses the branch alias for master (so an upper bound) instead of assuming that the current Box releases will be compatible with BC breaking changes in phpseclib master in the future.
