### PR TITLE
Added custom error if error_get_last() does not return anything. v2

### DIFF
--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -592,7 +592,10 @@ class Configuration
             $path = $this->getBasePath() . DIRECTORY_SEPARATOR . $path;
 
             if (false === ($contents = @file_get_contents($path))) {
-                $errors = error_get_last();
+                $errors = error_get_last();               
+                if ($errors === null) {
+                    $errors = array('message' => 'failed to get contents of \''.$path.'\'');
+                }
 
                 throw new RuntimeException($errors['message']);
             }
@@ -924,6 +927,9 @@ class Configuration
 
             if (false === ($contents = @file_get_contents($path))) {
                 $errors = error_get_last();
+                if ($errors === null) {
+                    $errors = array('message' => 'failed to get contents of \''.$path.'\'');
+                }
 
                 throw new RuntimeException($errors['message']);
             }

--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -592,7 +592,7 @@ class Configuration
             $path = $this->getBasePath() . DIRECTORY_SEPARATOR . $path;
 
             if (false === ($contents = @file_get_contents($path))) {
-                $errors = error_get_last();               
+                $errors = error_get_last();
                 if ($errors === null) {
                     $errors = array('message' => 'failed to get contents of \''.$path.'\'');
                 }


### PR DESCRIPTION
The set_error_handler function in the Application __construct method eats errors from file_get_contents. In this case box shows only a "[RuntimeException]" without any further hint and terminates. It was very frustrating to not see that I had a wrong path to my main-file in the box.json :-(.

Sorry that there is no test case for that in the PR. Phpunit has a custom error handler too and does not let you define own handlers. However without overwriting the handler there is no error that I could test for.
