### PR TITLE
Provide a way to disable the shebang

### DIFF
--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -871,7 +871,7 @@ class Configuration
         if (isset($this->raw->shebang)) {
             $shebang = trim($this->raw->shebang);
 
-            if ('#!' !== substr($shebang, 0, 2)) {
+            if ($shebang !== '' && '#!' !== substr($shebang, 0, 2)) {
                 throw new InvalidArgumentException(
                     sprintf(
                         'The shebang line must start with "#!": %s',


### PR DESCRIPTION
This is to fix #88. I am open to other ways of doing it such as overloading `shebang` to be either a string or `false`.
