### PR TITLE
Improve the apc_enable_cli check to avoid to report it only for APC

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -125,14 +125,16 @@ namespace
     }
 
     // check apc cli caching
-    check(
-        'The "apc.enable_cli" setting is off.',
-        'Notice: The "apc.enable_cli" is on and may cause problems with Phars.',
-        function () {
-            return (false == ini_get('apc.enable_cli'));
-        },
-        false
-    );
+    if (!defined('HHVM_VERSION') && !extension_loaded('apcu') && extension_loaded('apc')) {
+        check(
+            'The "apc.enable_cli" setting is off.',
+            'Notice: The "apc.enable_cli" is on and may cause problems with Phars.',
+            function () {
+                return (false == ini_get('apc.enable_cli'));
+            },
+            false
+        );
+    }
 
     echo "{$n}Everything seems good!$n$n";
 


### PR DESCRIPTION
APCu is not affected by the issue given that that it is in the opcode cache part of APC.
