### PR TITLE
Command: missing bootstrap loading fixed

### DIFF
--- a/src/lib/KevinGH/Box/Command/Add.php
+++ b/src/lib/KevinGH/Box/Command/Add.php
@@ -132,6 +132,7 @@ HELP
 
         // load bootstrap file
         if (null !== ($bootstrap = $this->config->getBootstrapFile())) {
+            $this->config->loadBootstrap();
             $this->putln('?', "Loading bootstrap file: $bootstrap");
 
             unset($bootstrap);

--- a/src/lib/KevinGH/Box/Command/Build.php
+++ b/src/lib/KevinGH/Box/Command/Build.php
@@ -395,6 +395,7 @@ HELP
 
         // load bootstrap file
         if (null !== ($bootstrap = $this->config->getBootstrapFile())) {
+            $this->config->loadBootstrap();
             $this->putln('?', "Loading bootstrap file: $bootstrap");
 
             unset($bootstrap);


### PR DESCRIPTION
There is actually silent error ATM when loading bootstrap.
This should really load it.

It's never used, only in tests, see [loadBootstrap method presence](https://github.com/box-project/box2/search?utf8=%E2%9C%93&q=loadBootstrap)
