### PR TITLE
Improve the travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,31 @@
 language: php
 
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
 php:
     - 5.3
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - hhvm
+    
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: hhvm
+        - php: 7.0
+
+before_install:
+    - composer self-update
+
+install:
+    - composer install
 
 before_script:
     - git config --global user.email test@test.com
     - git config --global user.name "Test User"
-    - composer self-update
-    - composer install --dev --no-interaction --prefer-source


### PR DESCRIPTION
- switch to the container-based infrastructure rather than the legacy one
- persist the composer download cache between builds to reuse downloaded archives
- add testing on HHVM and PHP 7
