### PR TITLE
Adds release date replacement (closes #103)

### DIFF
--- a/src/lib/KevinGH/Box/Command/Build.php
+++ b/src/lib/KevinGH/Box/Command/Build.php
@@ -257,6 +257,11 @@ It may be useful to know that Box imports files in the following order:
  - files
  - files-bin
 </comment>
+The <info>datetime</info> <comment>(string)</comment> setting is the name of a placeholder value that
+will be replaced in all non-binary files by the current datetime.
+
+Example: <comment>2015-01-28 14:55:23</comment>
+
 The <info>git-commit</info> <comment>(string)</comment> setting is the name of a placeholder value that
 will be replaced in all non-binary files by the current Git commit hash
 of the repository.

--- a/src/lib/KevinGH/Box/Command/Build.php
+++ b/src/lib/KevinGH/Box/Command/Build.php
@@ -66,6 +66,8 @@ Note that all settings are optional.
     "chmod": ?,
     "compactors": ?,
     "compression": ?,
+    "datetime": ?,
+    "datetime_format": ?,
     "directories": ?,
     "directories-bin": ?,
     "extract": ?,
@@ -261,6 +263,10 @@ The <info>datetime</info> <comment>(string)</comment> setting is the name of a p
 will be replaced in all non-binary files by the current datetime.
 
 Example: <comment>2015-01-28 14:55:23</comment>
+
+The <info>datetime_format</info> <comment>(string)</comment> setting accepts a valid PHP date format. It can be used to change the format for the <info>datetime</info> setting.
+
+Example: <comment>Y-m-d H:i:s</comment>
 
 The <info>git-commit</info> <comment>(string)</comment> setting is the name of a placeholder value that
 will be replaced in all non-binary files by the current Git commit hash

--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -843,6 +843,10 @@ class Configuration
             $values[$git] = $this->getGitVersion();
         }
 
+        if (null !== ($date = $this->getDatetimeNowPlaceHolder())) {
+            $values[$date] = $this->getDatetimeNow();
+        }
+
         $sigil = $this->getReplacementSigil();
 
         foreach ($values as $key => $value) {

--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -475,6 +475,22 @@ class Configuration
         return array();
     }
 
+    public function getDatetimeNow()
+    {
+        $now = new \Datetime('now');
+
+        return $now->format('Y-m-d H:i:s');
+    }
+
+    public function getDatetimeNowPlaceHolder()
+    {
+        if (isset($this->raw->{'datetime'})) {
+            return $this->raw->{'datetime'};
+        }
+
+        return null;
+    }
+
     /**
      * Returns the Git commit hash.
      *

--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -475,11 +475,16 @@ class Configuration
         return array();
     }
 
-    public function getDatetimeNow()
+    public function getDatetimeNow($format)
     {
         $now = new \Datetime('now');
+        $datetime = $now->format($format);
 
-        return $now->format('Y-m-d H:i:s');
+        if (!$datetime) {
+            throw new RuntimeException("'$format' is not a valid PHP date format");
+        }
+
+        return $datetime;
     }
 
     public function getDatetimeNowPlaceHolder()
@@ -489,6 +494,15 @@ class Configuration
         }
 
         return null;
+    }
+
+    public function getDatetimeFormat()
+    {
+        if (isset($this->raw->{'datetime_format'})) {
+            return $this->raw->{'datetime_format'};
+        }
+
+        return 'Y-m-d H:i:s';
     }
 
     /**
@@ -844,7 +858,7 @@ class Configuration
         }
 
         if (null !== ($date = $this->getDatetimeNowPlaceHolder())) {
-            $values[$date] = $this->getDatetimeNow();
+            $values[$date] = $this->getDatetimeNow($this->getDatetimeFormat());
         }
 
         $sigil = $this->getReplacementSigil();

--- a/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
+++ b/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
@@ -503,6 +503,27 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('test.html', $results[1]->getBasename());
     }
 
+    public function testGetDatetimeNow()
+    {
+        $this->assertRegExp(
+            '/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/',
+            $this->config->getDatetimeNow()
+        );
+    }
+
+    public function testGetDatetimeNowPlaceHolder()
+    {
+        $this->assertNull($this->config->getDatetimeNowPlaceHolder());
+
+        $this->setConfig(array('datetime' => 'date_time'));
+
+        $this->assertEquals(
+            'date_time',
+            $this->config->getDatetimeNowPlaceHolder()
+        );
+
+    }
+
     public function testGetGitHash()
     {
         touch('test');

--- a/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
+++ b/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
@@ -926,7 +926,8 @@ class ConfigurationTest extends TestCase
                 'git-commit-short' => 'git_commit_short',
                 'git-tag' => 'git_tag',
                 'git-version' => 'git_version',
-                'replacements' => array('rand' => $rand = rand())
+                'replacements' => array('rand' => $rand = rand()),
+                'datetime' => 'date_time'
             )
         );
 
@@ -937,6 +938,10 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('1.0.0', $values['@git_tag@']);
         $this->assertEquals('1.0.0', $values['@git_version@']);
         $this->assertEquals($rand, $values['@rand@']);
+        $this->assertRegExp(
+            '/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/',
+            $values['@date_time@']
+        );
 
         // some process does not release the git files
         if ($this->isWindows()) {

--- a/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
+++ b/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
@@ -507,7 +507,15 @@ class ConfigurationTest extends TestCase
     {
         $this->assertRegExp(
             '/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/',
-            $this->config->getDatetimeNow()
+            $this->config->getDatetimeNow('Y-m-d H:i:s')
+        );
+    }
+
+    public function testGetDatetimeNowFormatted()
+    {
+        $this->assertRegExp(
+            '/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/',
+            $this->config->getDatetimeNow('Y-m-d')
         );
     }
 
@@ -520,6 +528,19 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(
             'date_time',
             $this->config->getDatetimeNowPlaceHolder()
+        );
+
+    }
+
+    public function testGetDatetimeFormat()
+    {
+        $this->assertEquals('Y-m-d H:i:s', $this->config->getDatetimeFormat());
+
+        $this->setConfig(array('datetime_format' => 'Y-m-d'));
+
+        $this->assertEquals(
+            'Y-m-d',
+            $this->config->getDatetimeFormat()
         );
 
     }
@@ -927,7 +948,8 @@ class ConfigurationTest extends TestCase
                 'git-tag' => 'git_tag',
                 'git-version' => 'git_version',
                 'replacements' => array('rand' => $rand = rand()),
-                'datetime' => 'date_time'
+                'datetime' => 'date_time',
+                'datetime_format' => 'Y:m:d'
             )
         );
 
@@ -939,7 +961,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('1.0.0', $values['@git_version@']);
         $this->assertEquals($rand, $values['@rand@']);
         $this->assertRegExp(
-            '/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/',
+            '/^[0-9]{4}:[0-9]{2}:[0-9]{2}$/',
             $values['@date_time@']
         );
 


### PR DESCRIPTION
As mentioned in #103 it would be nice to specify a release date a la composer. The placeholder name is `datetime` but maybe `releasedate`could be more meaningful.

As of now the output is a string like `2015-10-28 10:34:23`
