### PR TITLE
Speed-up phar build process

### DIFF
--- a/src/lib/KevinGH/Box/Command/Build.php
+++ b/src/lib/KevinGH/Box/Command/Build.php
@@ -429,6 +429,7 @@ HELP
         $this->putln('?', "Output path: $path");
 
         $this->box = Box::create($path);
+        $this->box->getPhar()->startBuffering();
 
         // set replacement values, if any
         if (array() !== ($values = $this->config->getProcessedReplacements())) {


### PR DESCRIPTION
It helps if startBuffering is called when creating a new phar archive.
As the stopBuffering is called I suppose that someone missed the startBuffering directive.

The build times before and after...

```
time ../box/bin/box build
Building...

real    0m44.691s
user    0m21.601s
sys     0m13.337s
```

after

```
time ../box/bin/box build         Building...

real    0m24.135s
user    0m17.877s
sys     0m6.212s
```
