### PR TITLE
Use SSL-enabled URI for manifest.json

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -144,7 +144,7 @@ namespace
     // Retrieve manifest
     echo " - Downloading manifest...$n";
 
-    $manifest = file_get_contents('http://box-project.github.io/box2/manifest.json');
+    $manifest = file_get_contents('https://box-project.github.io/box2/manifest.json');
 
     echo " - Reading manifest...$n";
 


### PR DESCRIPTION
The script was using a non-SSL-enabled URI for the `manifest.json`, which could allow a MITM attack to provide an alternative file, and thus slipstream in insecure URIs for the `box.phar` locations.

Considering the `manifest.json` uses SSL-enabled URIs for the PHAR downloads themselves, the assumption is already that PHP can perform the SSL/TLS negotiation, so there's no reason not to use the SSL/TLS for retrieving the manifest itself.
