### PR TITLE
Remove trailing slashes form the configured directories

### DIFF
--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -369,7 +369,7 @@ class Configuration
                 function (&$directory) use ($base) {
                     $directory = $base
                                . DIRECTORY_SEPARATOR
-                               . Path::canonical($directory);
+                               . rtrim(Path::canonical($directory), '/');
                 }
             );
 

--- a/src/lib/KevinGH/Box/Configuration.php
+++ b/src/lib/KevinGH/Box/Configuration.php
@@ -369,7 +369,7 @@ class Configuration
                 function (&$directory) use ($base) {
                     $directory = $base
                                . DIRECTORY_SEPARATOR
-                               . rtrim(Path::canonical($directory), '/');
+                               . rtrim(Path::canonical($directory), DIRECTORY_SEPARATOR);
                 }
             );
 

--- a/src/tests/KevinGH/Box/Tests/Command/ValidateTest.php
+++ b/src/tests/KevinGH/Box/Tests/Command/ValidateTest.php
@@ -107,7 +107,7 @@ OUTPUT;
 Validating the Box configuration file...
 The configuration file failed validation.
 
-  - The property - test - is not defined and the definition does not allow additional properties
+  - The property test is not defined and the definition does not allow additional properties
 
 OUTPUT;
 

--- a/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
+++ b/src/tests/KevinGH/Box/Tests/ConfigurationTest.php
@@ -373,6 +373,21 @@ class ConfigurationTest extends TestCase
         );
     }
 
+    public function testGetDirectoriesTrailingSlashRemoved()
+    {
+        $this->setConfig(
+            array('directories' => array('dir/subdir1/', 'dir/subdir2/'))
+        );
+
+        $this->assertEquals(
+            array(
+                $this->dir . DIRECTORY_SEPARATOR . 'dir/subdir1',
+                $this->dir . DIRECTORY_SEPARATOR . 'dir/subdir2',
+            ),
+            $this->config->getDirectories()
+        );
+    }
+
     public function testGetDirectoriesIterator()
     {
         $this->assertNull($this->config->getDirectoriesIterator());


### PR DESCRIPTION
This PR fixes two issues:
1. a failing test was introduced with 6f50fded0b3e156237027b7680cb28eae0d3e4e0
2. build configurations that contain trailing slash in the directories section will fail, as explained in https://github.com/symfony/symfony-installer/pull/238

It maybe just a documentation issue (it's not stated anywhere if trailing slashes are forbidden), but since it is recoverable in code, I implemented it it along with some tests.
