### PR TITLE
Compress files on add instead of using Phar::compressFiles (fixes #80)

### DIFF
--- a/src/lib/KevinGH/Box/Command/Build.php
+++ b/src/lib/KevinGH/Box/Command/Build.php
@@ -586,13 +586,6 @@ HELP
             $this->box->getPhar()->setMetadata($metadata);
         }
 
-        // compress, if algorithm set
-        if (null !== ($algorithm = $this->config->getCompressionAlgorithm())) {
-            $this->putln('?', 'Compressing...');
-
-            $this->box->getPhar()->compressFiles($algorithm);
-        }
-
         $this->box->getPhar()->stopBuffering();
 
         // sign using private key, if applicable
@@ -661,6 +654,8 @@ HELP
             }
 
             $box = $binary ? $this->box->getPhar() : $this->box;
+            $phar = $this->box->getPhar();
+            $algorithm = $this->config->getCompressionAlgorithm();
             $baseRegex = $this->config->getBasePathRegex();
             $mapper = $this->config->getMapper();
 
@@ -694,6 +689,9 @@ HELP
                 }
 
                 $box->addFile($file, $relative);
+                if (null !== $algorithm) {
+                    $phar[$relative]->compress($algorithm);
+                }
             }
         }
     }

--- a/src/tests/KevinGH/Box/Tests/Command/BuildTest.php
+++ b/src/tests/KevinGH/Box/Tests/Command/BuildTest.php
@@ -392,7 +392,6 @@ OUTPUT;
   + {$dir}test.php
 ? Adding main file: {$dir}test.php
 ? Generating new stub...
-? Compressing...
 * Done.
 
 OUTPUT;


### PR DESCRIPTION
Apply file compression when adding a file instead of using Phar::compressFiles at the end.
This avoid the issue of opening too many files. 

On my project the build even runs faster for ~1200 files.

Tests with compressFiles: 

```
Building...

real    0m23.524s
user    0m14.499s
sys     0m8.972s
```

New version with compress on the fly

```
Building...

real    0m19.612s
user    0m10.440s
sys     0m9.135s
```
