### PR TITLE
Automatically set phar.readonly=0

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -36,5 +36,6 @@
     "replacements": {
         "manifest_url": "http://box-project.github.io/box2/manifest.json"
     },
+    "shebang": "#!/usr/bin/env php -d phar.readonly=0",
     "stub": true
 }


### PR DESCRIPTION
Rather than forcing users to change their php.ini settings or manually add a CLI flag on every run, set the phar.readonly=0 option in the shebang for box itself.
