### PR TITLE
Only PHP 5.5.9+ is supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/box-project/box2/issues"
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.9",
         "herrera-io/annotations": "~1.0",
         "herrera-io/box": "~1.6",
         "herrera-io/json": "~1.0",


### PR DESCRIPTION
I don't really expect this to be merged, but I'm putting this here to emphasise the fact that this is now the minimum version needed to use your phars as of 2 releases ago.
