### PR TITLE
Box as a composer dependency cannot find the correct autoload.php

### DIFF
--- a/bin/box
+++ b/bin/box
@@ -13,7 +13,7 @@ if (extension_loaded('phar') && ($uri = Phar::running())) {
 } elseif (class_exists('Extract')) {
     require __DIR__ . '/../src/vendors/autoload.php';
 } else {
-    loadComposerClassloader(realpath($_SERVER['argv'][0]));
+    loadComposerClassloader(realpath($_SERVER['argv'][0]), 1);
 }
 
 $app = new KevinGH\Box\Application();
@@ -45,6 +45,7 @@ function loadComposerClassloader($dir = null, $skip = 0)
             }
 
             $path = realpath("$dir/composer.json");
+            break;
         }
     } while ($dir !== ($up = dirname($dir)));
 


### PR DESCRIPTION
I'm not sure if this change actually breaks existing behavior, but I think the idea was that if you found a `composer.json` file, you wanted to exit the do-while loop, not exit only when the while condition is true.

I've added a `skip = 1` because we obviously want to skip the composer.json in the `box` directory (vendor/kerge/box).
