### PR TITLE
Fix the verbosity detection

### DIFF
--- a/src/lib/KevinGH/Box/Command/AbstractCommand.php
+++ b/src/lib/KevinGH/Box/Command/AbstractCommand.php
@@ -37,7 +37,7 @@ abstract class AbstractCommand extends Command
      */
     protected function isVerbose()
     {
-        return (OutputInterface::VERBOSITY_VERBOSE === $this->output->getVerbosity());
+        return (OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity());
     }
 
     /**


### PR DESCRIPTION
The equality check means that using higher verbosity levels would be considered as non-verbose
