### PR TITLE
Fix the composer autoloader location for cgr

### DIFF
--- a/bin/box
+++ b/bin/box
@@ -23,37 +23,59 @@ $app->run();
  * Finds the Composer autoloader and returns it.
  *
  * @param null $dir  The starting directory.
- * @param int  $skip The number of occurrences to skip.
  *
  * @return Composer\Autoload\ClassLoader The class loader.
  *
  * @throws RuntimeException If the loader could not be loaded.
  */
-function loadComposerClassloader($dir = null, $skip = 0)
+function loadComposerClassloader($dir = null)
 {
     $up = $dir;
-    $skips = 0;
+    $jsonPath = '';
+    $autoloaderPath = '';
 
     do {
         $dir = $up;
 
         if (file_exists("$dir/composer.json")) {
-            if ($skip > $skips) {
-                $skips++;
-
-                continue;
-            }
-
-            $path = realpath("$dir/composer.json");
+            $jsonPath = realpath("$dir/composer.json");
+            $vendorPath = $dir . DIRECTORY_SEPARATOR . getVendorDirectoryName($jsonPath);
+            $autoloaderPath = $vendorPath . DIRECTORY_SEPARATOR . 'autoload.php';
         }
-    } while ($dir !== ($up = dirname($dir)));
 
-    if (empty($path)) {
+        $up = dirname($dir);
+    } while ($dir !== $up && (!file_exists($autoloaderPath)));
+
+    if (empty($jsonPath)) {
         throw new RuntimeException(
             'The composer.json file could not be found.'
         );
     }
 
+    if (empty($autoloaderPath)) {
+        throw new RuntimeException(
+            'The composer autoload.php file could not be found.'
+        );
+    }
+
+    if (false === file_exists($autoloaderPath)) {
+        throw new RuntimeException(
+            sprintf(
+                'The Composer class loader "%s" could not be found.',
+                $autoloaderPath
+            )
+        );
+    }
+
+    return include $autoloaderPath;
+}
+
+/**
+ * @param $path Path of the composer.json
+ * @return string The name of the vendor directory
+ */
+function getVendorDirectoryName($path)
+{
     if (false === ($json = file_get_contents($path))) {
         throw new RuntimeException(
             sprintf(
@@ -75,24 +97,9 @@ function loadComposerClassloader($dir = null, $skip = 0)
         );
     }
 
-    $path = dirname($path);
-
     if (isset($json->config) && isset($json->config->{'vendor-dir'})) {
-        $path .= DIRECTORY_SEPARATOR . $json->config->{'vendor-dir'};
-    } else {
-        $path .= DIRECTORY_SEPARATOR . 'vendor';
+        return $json->config->{'vendor-dir'};
     }
 
-    $path .= DIRECTORY_SEPARATOR . 'autoload.php';
-
-    if (false === file_exists($path)) {
-        throw new RuntimeException(
-            sprintf(
-                'The Composer class loader "%s" could not be found.',
-                $path
-            )
-        );
-    }
-
-    return include $path;
+    return 'vendor';
 }


### PR DESCRIPTION
There is a tool called cgr (for composer global require) that
install every tool that needs to be globaly available in their own
custom folder. It does so that each tool dependecy don't infuences
other tools dependencies.

This means that the logic that was previously used by the autoloader
location code for box is broken. For some reason the code used to look
for the last autoloader in the folder structure ( the one closest to
the root folder ). I have no idea why it was doing so.

For [cgr](https://github.com/consolidation/cgr) to work it needs to be the first one found that needs to be
used. I have changed the logic accordingly in this PR as well as
removed some dead code (an option that was never used).

Any comment ?